### PR TITLE
reduce rbac privileges

### DIFF
--- a/_out/manifests/release/mtq-operator.yaml
+++ b/_out/manifests/release/mtq-operator.yaml
@@ -2010,40 +2010,37 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterrolebindings
   - clusterroles
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  verbs:
+  - create
   - get
   - list
   - watch
   - delete
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   - customresourcedefinitions/status
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - mtq.kubevirt.io
   resources:
-  - '*'
+  - mtqs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - scheduling.k8s.io
   resources:
@@ -2178,14 +2175,36 @@ rules:
   - secrets
   - services
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
 - apiGroups:
   - apps
   resources:
   - deployments
   - deployments/finalizers
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -2205,6 +2224,18 @@ rules:
   - leases
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/_out/manifests/templates/release/mtq-operator.yaml.j2
+++ b/_out/manifests/templates/release/mtq-operator.yaml.j2
@@ -2010,40 +2010,37 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterrolebindings
   - clusterroles
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  verbs:
+  - create
   - get
   - list
   - watch
   - delete
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   - customresourcedefinitions/status
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - mtq.kubevirt.io
   resources:
-  - '*'
+  - mtqs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - scheduling.k8s.io
   resources:
@@ -2178,14 +2175,36 @@ rules:
   - secrets
   - services
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
 - apiGroups:
   - apps
   resources:
   - deployments
   - deployments/finalizers
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -2205,6 +2224,18 @@ rules:
   - leases
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/generated/operator-everything.yaml.in
+++ b/manifests/generated/operator-everything.yaml.in
@@ -2004,40 +2004,37 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterrolebindings
   - clusterroles
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  verbs:
+  - create
   - get
   - list
   - watch
   - delete
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   - customresourcedefinitions/status
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - mtq.kubevirt.io
   resources:
-  - '*'
+  - mtqs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - scheduling.k8s.io
   resources:
@@ -2172,14 +2169,36 @@ rules:
   - secrets
   - services
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
 - apiGroups:
   - apps
   resources:
   - deployments
   - deployments/finalizers
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -2199,6 +2218,18 @@ rules:
   - leases
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/generated/operator-everything.yaml.in.j2
+++ b/manifests/generated/operator-everything.yaml.in.j2
@@ -2004,40 +2004,37 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterrolebindings
   - clusterroles
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  verbs:
+  - create
   - get
   - list
   - watch
   - delete
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   - customresourcedefinitions/status
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - mtq.kubevirt.io
   resources:
-  - '*'
+  - mtqs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - scheduling.k8s.io
   resources:
@@ -2172,14 +2169,36 @@ rules:
   - secrets
   - services
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
 - apiGroups:
   - apps
   resources:
   - deployments
   - deployments/finalizers
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -2199,6 +2218,18 @@ rules:
   - leases
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/mtq-operator/resources/operator/operator.go
+++ b/pkg/mtq-operator/resources/operator/operator.go
@@ -33,38 +33,16 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"rbac.authorization.k8s.io",
 			},
 			Resources: []string{
-				"rolebindings",
-				"roles",
-			},
-			Verbs: []string{
-				"*",
-			},
-		},
-		{
-			APIGroups: []string{
-				"rbac.authorization.k8s.io",
-			},
-			Resources: []string{
 				"clusterrolebindings",
 				"clusterroles",
 			},
 			Verbs: []string{
-				"*",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"pods",
-				"services",
-			},
-			Verbs: []string{
+				"create",
 				"get",
 				"list",
 				"watch",
 				"delete",
+				"update",
 			},
 		},
 		{
@@ -76,7 +54,12 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"customresourcedefinitions/status",
 			},
 			Verbs: []string{
-				"*",
+				"create",
+				"get",
+				"list",
+				"watch",
+				"delete",
+				"update",
 			},
 		},
 		{
@@ -84,10 +67,14 @@ func getClusterPolicyRules() []rbacv1.PolicyRule {
 				"mtq.kubevirt.io",
 			},
 			Resources: []string{
-				"*",
+				"mtqs",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"delete",
+				"update",
 			},
 		},
 		{
@@ -137,7 +124,29 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"services",
 			},
 			Verbs: []string{
-				"*",
+				"create",
+				"get",
+				"list",
+				"watch",
+				"delete",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"pods",
+				"services",
+				"endpoints",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
 			},
 		},
 		{
@@ -149,7 +158,12 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"deployments/finalizers",
 			},
 			Verbs: []string{
-				"*",
+				"create",
+				"get",
+				"list",
+				"watch",
+				"delete",
+				"update",
 			},
 		},
 		{
@@ -178,7 +192,30 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"leases",
 			},
 			Verbs: []string{
-				"*",
+				"get",
+				"list",
+				"watch",
+				"delete",
+				"update",
+				"create",
+				"patch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"rbac.authorization.k8s.io",
+			},
+			Resources: []string{
+				"rolebindings",
+				"roles",
+			},
+			Verbs: []string{
+				"create",
+				"get",
+				"list",
+				"watch",
+				"delete",
+				"update",
 			},
 		},
 	}


### PR DESCRIPTION
There are some permissions that are logically not needed, and some others where we can just reduce the verb set.

Trying to follow https://kubernetes.io/docs/concepts/security/rbac-good-practices/

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
