### PR TITLE
Add RBAC for configmaps finalizers for mtq-operator

### DIFF
--- a/pkg/mtq-operator/resources/operator/operator.go
+++ b/pkg/mtq-operator/resources/operator/operator.go
@@ -137,6 +137,17 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"",
 			},
 			Resources: []string{
+				"configmaps/finalizers",
+			},
+			Verbs: []string{
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
 				"pods",
 				"services",
 				"endpoints",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
mtq-operator is failing to set owner reference on the mtq-config configmap, because it is not allowed to set finalizers on it:
`2023-09-15T06:17:02.476758762Z {"level":"error","ts":"2023-09-15T06:17:02Z","msg":"Reconciler error","controller":"mtq-operator-controller","object":{"name":"mtq-kubevirt-hyperconverged"},"namespace":"","name":"mtq-kubevirt-hyperconverged","reconcileID":"f1a247f3-28bf-45c8-a6f3-c607433a0ce8","error":"configmaps \"mtq-config\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workdir/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/workdir/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/workdir/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235"}`

According to operator-sdk, an `update` verb on the resource's finalizer should be allowed:
https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix configmap finalizers RBAC for mtq-operator
```
