### PR TITLE
Bump kubevirt to v1.0.0 and add limit range support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ else
 endif
 
 ifeq ($(origin KUBEVIRT_RELEASE), undefined)
-	KUBEVIRT_RELEASE="latest_nightly"
+	KUBEVIRT_RELEASE="latest_stable"
 endif
 
 all: manifests build-images

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/spf13/cobra v1.6.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/genproto v0.0.0-20220720214146-176da50484ac // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 require (
 	github.com/appscode/jsonpatch v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -53,6 +52,7 @@ require (
 
 require (
 	github.com/coreos/go-semver v0.3.0
+	github.com/emicklei/go-restful/v3 v3.9.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.9.5
@@ -125,12 +125,12 @@ require (
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/kubernetes v1.26.3
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
-	kubevirt.io/api v1.0.0-rc.0
-	kubevirt.io/client-go v1.0.0-rc.0
+	kubevirt.io/api v1.0.0
+	kubevirt.io/client-go v1.0.0
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1
 	kubevirt.io/controller-lifecycle-operator-sdk v0.2.4
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
-	kubevirt.io/kubevirt v1.0.0-rc.0
+	kubevirt.io/kubevirt v1.0.0
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1950,10 +1950,10 @@ k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20221107191617-1a15be271d1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106 h1:EObNQ3TW2D+WptiYXlApGNLVy0zm/JIBVY9i+M4wpAU=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-kubevirt.io/api v1.0.0-rc.0 h1:tG2MaBGkwdloMJieHEyHHvwvUwV11hNn/snlXvrmdIQ=
-kubevirt.io/api v1.0.0-rc.0/go.mod h1:CJ4vZsaWhVN3jNbyc9y3lIZhw8nUHbWjap0xHABQiqc=
-kubevirt.io/client-go v1.0.0-rc.0 h1:1YX2gsTIAw5wa9Glrlo37NtJlo8PPRAqpbCWZbu2q84=
-kubevirt.io/client-go v1.0.0-rc.0/go.mod h1:ZhWCbwAHkRDJIZ2Iy7dLMJpSrWoXWHxDKlF6yz7T1FE=
+kubevirt.io/api v1.0.0 h1:RBdXP5CDhE0v5qL2OUQdrYyRrHe/F68Z91GWqBDF6nw=
+kubevirt.io/api v1.0.0/go.mod h1:CJ4vZsaWhVN3jNbyc9y3lIZhw8nUHbWjap0xHABQiqc=
+kubevirt.io/client-go v1.0.0 h1:MMn41j/lFd+lJ7gWn7yuIZYW/aT9fI3bUimAuxAQ+Xk=
+kubevirt.io/client-go v1.0.0/go.mod h1:zvYQ/L5OmTP2Pn7XcawtoR07p8VhgviADWtgdGCniWA=
 kubevirt.io/containerized-data-importer v1.56.0 h1:3HjrFVRbzAkL/6MEUoNpaiNS+EuVXQ/Ox5h8wDw5kTs=
 kubevirt.io/containerized-data-importer v1.56.0/go.mod h1:vPg/z+FjgNgXtwcYVpGmW2FJ8dVSuKZb2jEwoNRoMfM=
 kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 h1:IWo12+ei3jltSN5jQN1xjgakfvRSF3G3Rr4GXVOOy2I=
@@ -1962,8 +1962,8 @@ kubevirt.io/controller-lifecycle-operator-sdk v0.2.4 h1:H+VDfGgc85S6MsstwXxCtiwT
 kubevirt.io/controller-lifecycle-operator-sdk v0.2.4/go.mod h1:JlY8c5nFxNZCo3ns1pFqstPJbjgBFh6+9FuL2/5cDfk=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
-kubevirt.io/kubevirt v1.0.0-rc.0 h1:aYT3e+jFUYMfKUyBodL0zt6+4pKAzA687Zl5JOI39wo=
-kubevirt.io/kubevirt v1.0.0-rc.0/go.mod h1:k6z7NJFBFh6EJKrK8kBIs5+rvTC9Ov+cExtFuSxdcg4=
+kubevirt.io/kubevirt v1.0.0 h1:9K21GCiqTW8vcs9Y8izRsU+0zP3TPHNS15teHu/ieuY=
+kubevirt.io/kubevirt v1.0.0/go.mod h1:k6z7NJFBFh6EJKrK8kBIs5+rvTC9Ov+cExtFuSxdcg4=
 kubevirt.io/qe-tools v0.1.8 h1:Ar7qicmzHdd+Ia+6rjHDg3D7GReIyq7QFXoC4F7TjhQ=
 kubevirt.io/qe-tools v0.1.8/go.mod h1:+Tr/WZGHIDQa/4pQgzM7+4J6YeVbUWAXESXtL2/zxqc=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=

--- a/go.sum
+++ b/go.sum
@@ -1409,6 +1409,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/mtq-controller/application.go
+++ b/pkg/mtq-controller/application.go
@@ -56,6 +56,7 @@ type MtqControllerApp struct {
 	mtqCli                v1alpha1.MtqV1alpha1Client
 	vmmrqController       *vmmrq_controller.VmmrqController
 	podInformer           cache.SharedIndexInformer
+	limitRangeInformer    cache.SharedIndexInformer
 	migrationInformer     cache.SharedIndexInformer
 	resourceQuotaInformer cache.SharedIndexInformer
 	vmmrqInformer         cache.SharedIndexInformer
@@ -103,6 +104,7 @@ func Execute() {
 
 	app.mtqCli = util.GetMTQCli()
 	app.podInformer = util.GetLauncherPodInformer(virtCli)
+	app.limitRangeInformer = util.GetlimitRangeInformer(virtCli)
 	app.vmmrqInformer = util.GetVirtualMachineMigrationResourceQuotaInformer(app.mtqCli)
 	app.resourceQuotaInformer = util.GetResourceQuotaInformer(virtCli)
 	app.vmiInformer = util.GetVMIInformer(virtCli)
@@ -142,6 +144,7 @@ func (mca *MtqControllerApp) initVmmrqController() {
 		mca.vmiInformer,
 		mca.migrationInformer,
 		mca.podInformer,
+		mca.limitRangeInformer,
 		mca.kubeVirtInformer,
 		mca.crdInformer,
 		mca.pvcInformer,
@@ -237,6 +240,7 @@ func (mca *MtqControllerApp) onStartedLeading() func(ctx context.Context) {
 		go mca.crdInformer.Run(stop)
 		go mca.pvcInformer.Run(stop)
 		go mca.podInformer.Run(stop)
+		go mca.limitRangeInformer.Run(stop)
 		go mca.vmmrqInformer.Run(stop)
 		go mca.resourceQuotaInformer.Run(stop)
 
@@ -246,6 +250,7 @@ func (mca *MtqControllerApp) onStartedLeading() func(ctx context.Context) {
 			mca.crdInformer.HasSynced,
 			mca.kubeVirtInformer.HasSynced,
 			mca.podInformer.HasSynced,
+			mca.limitRangeInformer.HasSynced,
 			mca.resourceQuotaInformer.HasSynced,
 			mca.vmmrqInformer.HasSynced,
 		) {

--- a/pkg/mtq-operator/resources/cluster/controller.go
+++ b/pkg/mtq-operator/resources/cluster/controller.go
@@ -100,6 +100,18 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"limitranges",
+			},
+			Verbs: []string{
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
 				"mtq.kubevirt.io",
 			},
 			Resources: []string{

--- a/pkg/util/informers.go
+++ b/pkg/util/informers.go
@@ -53,7 +53,7 @@ func GetMigrationInformer(virtCli kubecli.KubevirtClient) cache.SharedIndexInfor
 
 func GetVirtualMachineMigrationResourceQuotaInformer(mtqCli v1alpha12.MtqV1alpha1Client) cache.SharedIndexInformer {
 	listWatcher := NewListWatchFromClient(mtqCli.RESTClient(), "virtualmachinemigrationresourcequotas", k8sv1.NamespaceAll, fields.Everything(), labels.Everything())
-	return cache.NewSharedIndexInformer(listWatcher, & v1alpha13.VirtualMachineMigrationResourceQuota{}, 1*time.Hour, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	return cache.NewSharedIndexInformer(listWatcher, &v1alpha13.VirtualMachineMigrationResourceQuota{}, 1*time.Hour, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func GetLauncherPodInformer(virtCli kubecli.KubevirtClient) cache.SharedIndexInformer {
@@ -93,6 +93,10 @@ func CRDInformer(virtCli kubecli.KubevirtClient) cache.SharedIndexInformer {
 func GetResourceQuotaInformer(virtCli kubecli.KubevirtClient) cache.SharedIndexInformer {
 	listWatcher := NewListWatchFromClient(virtCli.CoreV1().RESTClient(), "resourcequotas", k8sv1.NamespaceAll, fields.Everything(), labels.Everything())
 	return cache.NewSharedIndexInformer(listWatcher, &v1.ResourceQuota{}, 1*time.Hour, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+}
+func GetlimitRangeInformer(virtCli kubecli.KubevirtClient) cache.SharedIndexInformer {
+	listWatcher := NewListWatchFromClient(virtCli.CoreV1().RESTClient(), "limitranges", k8sv1.NamespaceAll, fields.Everything(), labels.Everything())
+	return cache.NewSharedIndexInformer(listWatcher, &v1.LimitRange{}, 1*time.Hour, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func PersistentVolumeClaim(virtCli kubecli.KubevirtClient) cache.SharedIndexInformer {

--- a/tests/mtq_operator_test.go
+++ b/tests/mtq_operator_test.go
@@ -46,12 +46,20 @@ var _ = Describe("ALL Operator tests", func() {
 
 			// Condition flags can be found here with their meaning https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/docs/conditions.md
 			It("Condition flags on CR should be healthy and operating", func() {
-				mtqObject := getMTQ(f)
-				conditionMap := sdk.GetConditionValues(mtqObject.Status.Conditions)
-				// Application should be fully operational and healthy.
-				Expect(conditionMap[conditions.ConditionAvailable]).To(Equal(corev1.ConditionTrue))
-				Expect(conditionMap[conditions.ConditionProgressing]).To(Equal(corev1.ConditionFalse))
-				Expect(conditionMap[conditions.ConditionDegraded]).To(Equal(corev1.ConditionFalse))
+				Eventually(func() error {
+					mtqObject := getMTQ(f)
+					conditionMap := sdk.GetConditionValues(mtqObject.Status.Conditions)
+					if conditionMap[conditions.ConditionAvailable] != corev1.ConditionTrue {
+						return fmt.Errorf("ConditionAvailable is false")
+					}
+					if conditionMap[conditions.ConditionProgressing] != corev1.ConditionFalse {
+						return fmt.Errorf("ConditionProgressing is true")
+					}
+					if conditionMap[conditions.ConditionDegraded] != corev1.ConditionFalse {
+						return fmt.Errorf("ConditionDegraded is true")
+					}
+					return nil
+				}, 5*time.Minute, 2*time.Second).Should(BeNil())
 			})
 		})
 

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,205 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func newPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		c.wg.Done()
+		if g.m[key] == c {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission.go
@@ -1,0 +1,612 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitranger
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitailizer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/utils/lru"
+)
+
+const (
+	limitRangerAnnotation = "kubernetes.io/limit-ranger"
+	// PluginName indicates name of admission plugin.
+	PluginName = "LimitRanger"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewLimitRanger(&DefaultLimitRangerActions{})
+	})
+}
+
+// LimitRanger enforces usage limits on a per resource basis in the namespace
+type LimitRanger struct {
+	*admission.Handler
+	client  kubernetes.Interface
+	actions LimitRangerActions
+	lister  corev1listers.LimitRangeLister
+
+	// liveLookups holds the last few live lookups we've done to help ammortize cost on repeated lookup failures.
+	// This let's us handle the case of latent caches, by looking up actual results for a namespace on cache miss/no results.
+	// We track the lookup result here so that for repeated requests, we don't look it up very often.
+	liveLookupCache *lru.Cache
+	group           singleflight.Group
+	liveTTL         time.Duration
+}
+
+var _ admission.MutationInterface = &LimitRanger{}
+var _ admission.ValidationInterface = &LimitRanger{}
+
+var _ genericadmissioninitailizer.WantsExternalKubeInformerFactory = &LimitRanger{}
+var _ genericadmissioninitailizer.WantsExternalKubeClientSet = &LimitRanger{}
+
+type liveLookupEntry struct {
+	expiry time.Time
+	items  []*corev1.LimitRange
+}
+
+// SetExternalKubeInformerFactory registers an informer factory into the LimitRanger
+func (l *LimitRanger) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+	limitRangeInformer := f.Core().V1().LimitRanges()
+	l.SetReadyFunc(limitRangeInformer.Informer().HasSynced)
+	l.lister = limitRangeInformer.Lister()
+}
+
+// SetExternalKubeClientSet registers the client into LimitRanger
+func (l *LimitRanger) SetExternalKubeClientSet(client kubernetes.Interface) {
+	l.client = client
+}
+
+// ValidateInitialization verifies the LimitRanger object has been properly initialized
+func (l *LimitRanger) ValidateInitialization() error {
+	if l.lister == nil {
+		return fmt.Errorf("missing limitRange lister")
+	}
+	if l.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}
+
+// Admit admits resources into cluster that do not violate any defined LimitRange in the namespace
+func (l *LimitRanger) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	return l.runLimitFunc(a, l.actions.MutateLimit)
+}
+
+// Validate admits resources into cluster that do not violate any defined LimitRange in the namespace
+func (l *LimitRanger) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	return l.runLimitFunc(a, l.actions.ValidateLimit)
+}
+
+func (l *LimitRanger) runLimitFunc(a admission.Attributes, limitFn func(limitRange *corev1.LimitRange, kind string, obj runtime.Object) error) (err error) {
+	if !l.actions.SupportsAttributes(a) {
+		return nil
+	}
+
+	// ignore all objects marked for deletion
+	oldObj := a.GetOldObject()
+	if oldObj != nil {
+		oldAccessor, err := meta.Accessor(oldObj)
+		if err != nil {
+			return admission.NewForbidden(a, err)
+		}
+		if oldAccessor.GetDeletionTimestamp() != nil {
+			return nil
+		}
+	}
+
+	items, err := l.GetLimitRanges(a)
+	if err != nil {
+		return err
+	}
+
+	// ensure it meets each prescribed min/max
+	for i := range items {
+		limitRange := items[i]
+
+		if !l.actions.SupportsLimit(limitRange) {
+			continue
+		}
+
+		err = limitFn(limitRange, a.GetResource().Resource, a.GetObject())
+		if err != nil {
+			return admission.NewForbidden(a, err)
+		}
+	}
+	return nil
+}
+
+// GetLimitRanges returns a LimitRange object with the items held in
+// the indexer if available, or do alive lookup of the value.
+func (l *LimitRanger) GetLimitRanges(a admission.Attributes) ([]*corev1.LimitRange, error) {
+	items, err := l.lister.LimitRanges(a.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		return nil, admission.NewForbidden(a, fmt.Errorf("unable to %s %v at this time because there was an error enforcing limit ranges", a.GetOperation(), a.GetResource()))
+	}
+
+	// if there are no items held in our indexer, check our live-lookup LRU, if that misses, do the live lookup to prime it.
+	if len(items) == 0 {
+		lruItemObj, ok := l.liveLookupCache.Get(a.GetNamespace())
+		if !ok || lruItemObj.(liveLookupEntry).expiry.Before(time.Now()) {
+			// Fixed: #22422
+			// use singleflight to alleviate simultaneous calls to
+			lruItemObj, err, _ = l.group.Do(a.GetNamespace(), func() (interface{}, error) {
+				liveList, err := l.client.CoreV1().LimitRanges(a.GetNamespace()).List(context.TODO(), metav1.ListOptions{})
+				if err != nil {
+					return nil, admission.NewForbidden(a, err)
+				}
+				newEntry := liveLookupEntry{expiry: time.Now().Add(l.liveTTL)}
+				for i := range liveList.Items {
+					newEntry.items = append(newEntry.items, &liveList.Items[i])
+				}
+				l.liveLookupCache.Add(a.GetNamespace(), newEntry)
+				return newEntry, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		lruEntry := lruItemObj.(liveLookupEntry)
+
+		for i := range lruEntry.items {
+			items = append(items, lruEntry.items[i])
+		}
+
+	}
+
+	return items, nil
+}
+
+// NewLimitRanger returns an object that enforces limits based on the supplied limit function
+func NewLimitRanger(actions LimitRangerActions) (*LimitRanger, error) {
+	liveLookupCache := lru.New(10000)
+
+	if actions == nil {
+		actions = &DefaultLimitRangerActions{}
+	}
+
+	return &LimitRanger{
+		Handler:         admission.NewHandler(admission.Create, admission.Update),
+		actions:         actions,
+		liveLookupCache: liveLookupCache,
+		liveTTL:         time.Duration(30 * time.Second),
+	}, nil
+}
+
+// defaultContainerResourceRequirements returns the default requirements for a container
+// the requirement.Limits are taken from the LimitRange defaults (if specified)
+// the requirement.Requests are taken from the LimitRange default request (if specified)
+func defaultContainerResourceRequirements(limitRange *corev1.LimitRange) api.ResourceRequirements {
+	requirements := api.ResourceRequirements{}
+	requirements.Requests = api.ResourceList{}
+	requirements.Limits = api.ResourceList{}
+
+	for i := range limitRange.Spec.Limits {
+		limit := limitRange.Spec.Limits[i]
+		if limit.Type == corev1.LimitTypeContainer {
+			for k, v := range limit.DefaultRequest {
+				requirements.Requests[api.ResourceName(k)] = v.DeepCopy()
+			}
+			for k, v := range limit.Default {
+				requirements.Limits[api.ResourceName(k)] = v.DeepCopy()
+			}
+		}
+	}
+	return requirements
+}
+
+// mergeContainerResources handles defaulting all of the resources on a container.
+func mergeContainerResources(container *api.Container, defaultRequirements *api.ResourceRequirements, annotationPrefix string, annotations []string) []string {
+	setRequests := []string{}
+	setLimits := []string{}
+	if container.Resources.Limits == nil {
+		container.Resources.Limits = api.ResourceList{}
+	}
+	if container.Resources.Requests == nil {
+		container.Resources.Requests = api.ResourceList{}
+	}
+	for k, v := range defaultRequirements.Limits {
+		_, found := container.Resources.Limits[k]
+		if !found {
+			container.Resources.Limits[k] = v.DeepCopy()
+			setLimits = append(setLimits, string(k))
+		}
+	}
+	for k, v := range defaultRequirements.Requests {
+		_, found := container.Resources.Requests[k]
+		if !found {
+			container.Resources.Requests[k] = v.DeepCopy()
+			setRequests = append(setRequests, string(k))
+		}
+	}
+	if len(setRequests) > 0 {
+		sort.Strings(setRequests)
+		a := strings.Join(setRequests, ", ") + fmt.Sprintf(" request for %s %s", annotationPrefix, container.Name)
+		annotations = append(annotations, a)
+	}
+	if len(setLimits) > 0 {
+		sort.Strings(setLimits)
+		a := strings.Join(setLimits, ", ") + fmt.Sprintf(" limit for %s %s", annotationPrefix, container.Name)
+		annotations = append(annotations, a)
+	}
+	return annotations
+}
+
+// mergePodResourceRequirements merges enumerated requirements with default requirements
+// it annotates the pod with information about what requirements were modified
+func mergePodResourceRequirements(pod *api.Pod, defaultRequirements *api.ResourceRequirements) {
+	annotations := []string{}
+
+	for i := range pod.Spec.Containers {
+		annotations = mergeContainerResources(&pod.Spec.Containers[i], defaultRequirements, "container", annotations)
+	}
+
+	for i := range pod.Spec.InitContainers {
+		annotations = mergeContainerResources(&pod.Spec.InitContainers[i], defaultRequirements, "init container", annotations)
+	}
+
+	if len(annotations) > 0 {
+		if pod.ObjectMeta.Annotations == nil {
+			pod.ObjectMeta.Annotations = make(map[string]string)
+		}
+		val := "LimitRanger plugin set: " + strings.Join(annotations, "; ")
+		pod.ObjectMeta.Annotations[limitRangerAnnotation] = val
+	}
+}
+
+// requestLimitEnforcedValues returns the specified values at a common precision to support comparability
+func requestLimitEnforcedValues(requestQuantity, limitQuantity, enforcedQuantity resource.Quantity) (request, limit, enforced int64) {
+	request = requestQuantity.Value()
+	limit = limitQuantity.Value()
+	enforced = enforcedQuantity.Value()
+	// do a more precise comparison if possible (if the value won't overflow)
+	if request <= resource.MaxMilliValue && limit <= resource.MaxMilliValue && enforced <= resource.MaxMilliValue {
+		request = requestQuantity.MilliValue()
+		limit = limitQuantity.MilliValue()
+		enforced = enforcedQuantity.MilliValue()
+	}
+	return
+}
+
+// minConstraint enforces the min constraint over the specified resource
+func minConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
+	req, reqExists := request[api.ResourceName(resourceName)]
+	lim, limExists := limit[api.ResourceName(resourceName)]
+	observedReqValue, observedLimValue, enforcedValue := requestLimitEnforcedValues(req, lim, enforced)
+
+	if !reqExists {
+		return fmt.Errorf("minimum %s usage per %s is %s.  No request is specified", resourceName, limitType, enforced.String())
+	}
+	if observedReqValue < enforcedValue {
+		return fmt.Errorf("minimum %s usage per %s is %s, but request is %s", resourceName, limitType, enforced.String(), req.String())
+	}
+	if limExists && (observedLimValue < enforcedValue) {
+		return fmt.Errorf("minimum %s usage per %s is %s, but limit is %s", resourceName, limitType, enforced.String(), lim.String())
+	}
+	return nil
+}
+
+// maxRequestConstraint enforces the max constraint over the specified resource
+// use when specify LimitType resource doesn't recognize limit values
+func maxRequestConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList) error {
+	req, reqExists := request[api.ResourceName(resourceName)]
+	observedReqValue, _, enforcedValue := requestLimitEnforcedValues(req, resource.Quantity{}, enforced)
+
+	if !reqExists {
+		return fmt.Errorf("maximum %s usage per %s is %s.  No request is specified", resourceName, limitType, enforced.String())
+	}
+	if observedReqValue > enforcedValue {
+		return fmt.Errorf("maximum %s usage per %s is %s, but request is %s", resourceName, limitType, enforced.String(), req.String())
+	}
+	return nil
+}
+
+// maxConstraint enforces the max constraint over the specified resource
+func maxConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
+	req, reqExists := request[api.ResourceName(resourceName)]
+	lim, limExists := limit[api.ResourceName(resourceName)]
+	observedReqValue, observedLimValue, enforcedValue := requestLimitEnforcedValues(req, lim, enforced)
+
+	if !limExists {
+		return fmt.Errorf("maximum %s usage per %s is %s.  No limit is specified", resourceName, limitType, enforced.String())
+	}
+	if observedLimValue > enforcedValue {
+		return fmt.Errorf("maximum %s usage per %s is %s, but limit is %s", resourceName, limitType, enforced.String(), lim.String())
+	}
+	if reqExists && (observedReqValue > enforcedValue) {
+		return fmt.Errorf("maximum %s usage per %s is %s, but request is %s", resourceName, limitType, enforced.String(), req.String())
+	}
+	return nil
+}
+
+// limitRequestRatioConstraint enforces the limit to request ratio over the specified resource
+func limitRequestRatioConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
+	req, reqExists := request[api.ResourceName(resourceName)]
+	lim, limExists := limit[api.ResourceName(resourceName)]
+	observedReqValue, observedLimValue, _ := requestLimitEnforcedValues(req, lim, enforced)
+
+	if !reqExists || (observedReqValue == int64(0)) {
+		return fmt.Errorf("%s max limit to request ratio per %s is %s, but no request is specified or request is 0", resourceName, limitType, enforced.String())
+	}
+	if !limExists || (observedLimValue == int64(0)) {
+		return fmt.Errorf("%s max limit to request ratio per %s is %s, but no limit is specified or limit is 0", resourceName, limitType, enforced.String())
+	}
+
+	observedRatio := float64(observedLimValue) / float64(observedReqValue)
+	displayObservedRatio := observedRatio
+	maxLimitRequestRatio := float64(enforced.Value())
+	if enforced.Value() <= resource.MaxMilliValue {
+		observedRatio = observedRatio * 1000
+		maxLimitRequestRatio = float64(enforced.MilliValue())
+	}
+
+	if observedRatio > maxLimitRequestRatio {
+		return fmt.Errorf("%s max limit to request ratio per %s is %s, but provided ratio is %f", resourceName, limitType, enforced.String(), displayObservedRatio)
+	}
+
+	return nil
+}
+
+// sum takes the total of each named resource across all inputs
+// if a key is not in each input, then the output resource list will omit the key
+func sum(inputs []api.ResourceList) api.ResourceList {
+	result := api.ResourceList{}
+	keys := []api.ResourceName{}
+	for i := range inputs {
+		for k := range inputs[i] {
+			keys = append(keys, k)
+		}
+	}
+	for _, key := range keys {
+		total, isSet := int64(0), true
+
+		for i := range inputs {
+			input := inputs[i]
+			v, exists := input[key]
+			if exists {
+				if key == api.ResourceCPU {
+					total = total + v.MilliValue()
+				} else {
+					total = total + v.Value()
+				}
+			} else {
+				isSet = false
+			}
+		}
+
+		if isSet {
+			if key == api.ResourceCPU {
+				result[key] = *(resource.NewMilliQuantity(total, resource.DecimalSI))
+			} else {
+				result[key] = *(resource.NewQuantity(total, resource.DecimalSI))
+			}
+
+		}
+	}
+	return result
+}
+
+// DefaultLimitRangerActions is the default implementation of LimitRangerActions.
+type DefaultLimitRangerActions struct{}
+
+// ensure DefaultLimitRangerActions implements the LimitRangerActions interface.
+var _ LimitRangerActions = &DefaultLimitRangerActions{}
+
+// MutateLimit enforces resource requirements of incoming resources
+// against enumerated constraints on the LimitRange.  It may modify
+// the incoming object to apply default resource requirements if not
+// specified, and enumerated on the LimitRange
+func (d *DefaultLimitRangerActions) MutateLimit(limitRange *corev1.LimitRange, resourceName string, obj runtime.Object) error {
+	switch resourceName {
+	case "pods":
+		return PodMutateLimitFunc(limitRange, obj.(*api.Pod))
+	}
+	return nil
+}
+
+// ValidateLimit verifies the resource requirements of incoming
+// resources against enumerated constraints on the LimitRange are
+// valid
+func (d *DefaultLimitRangerActions) ValidateLimit(limitRange *corev1.LimitRange, resourceName string, obj runtime.Object) error {
+	switch resourceName {
+	case "pods":
+		return PodValidateLimitFunc(limitRange, obj.(*api.Pod))
+	case "persistentvolumeclaims":
+		return PersistentVolumeClaimValidateLimitFunc(limitRange, obj.(*api.PersistentVolumeClaim))
+	}
+	return nil
+}
+
+// SupportsAttributes ignores all calls that do not deal with pod resources or storage requests (PVCs).
+// Also ignores any call that has a subresource defined.
+func (d *DefaultLimitRangerActions) SupportsAttributes(a admission.Attributes) bool {
+	if a.GetSubresource() != "" {
+		return false
+	}
+
+	// Since containers and initContainers cannot currently be added, removed, or updated, it is unnecessary
+	// to mutate and validate limitrange on pod updates. Trying to mutate containers or initContainers on a pod
+	// update request will always fail pod validation because those fields are immutable once the object is created.
+	if a.GetKind().GroupKind() == api.Kind("Pod") && a.GetOperation() == admission.Update {
+		return false
+	}
+
+	return a.GetKind().GroupKind() == api.Kind("Pod") || a.GetKind().GroupKind() == api.Kind("PersistentVolumeClaim")
+}
+
+// SupportsLimit always returns true.
+func (d *DefaultLimitRangerActions) SupportsLimit(limitRange *corev1.LimitRange) bool {
+	return true
+}
+
+// PersistentVolumeClaimValidateLimitFunc enforces storage limits for PVCs.
+// Users request storage via pvc.Spec.Resources.Requests.  Min/Max is enforced by an admin with LimitRange.
+// Claims will not be modified with default values because storage is a required part of pvc.Spec.
+// All storage enforced values *only* apply to pvc.Spec.Resources.Requests.
+func PersistentVolumeClaimValidateLimitFunc(limitRange *corev1.LimitRange, pvc *api.PersistentVolumeClaim) error {
+	var errs []error
+	for i := range limitRange.Spec.Limits {
+		limit := limitRange.Spec.Limits[i]
+		limitType := limit.Type
+		if limitType == corev1.LimitTypePersistentVolumeClaim {
+			for k, v := range limit.Min {
+				// normal usage of minConstraint. pvc.Spec.Resources.Limits is not recognized as user input
+				if err := minConstraint(string(limitType), string(k), v, pvc.Spec.Resources.Requests, api.ResourceList{}); err != nil {
+					errs = append(errs, err)
+				}
+			}
+			for k, v := range limit.Max {
+				// We want to enforce the max of the LimitRange against what
+				// the user requested.
+				if err := maxRequestConstraint(string(limitType), string(k), v, pvc.Spec.Resources.Requests); err != nil {
+					errs = append(errs, err)
+				}
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// PodMutateLimitFunc sets resource requirements enumerated by the pod against
+// the specified LimitRange.  The pod may be modified to apply default resource
+// requirements if not specified, and enumerated on the LimitRange
+func PodMutateLimitFunc(limitRange *corev1.LimitRange, pod *api.Pod) error {
+	defaultResources := defaultContainerResourceRequirements(limitRange)
+	mergePodResourceRequirements(pod, &defaultResources)
+	return nil
+}
+
+// PodValidateLimitFunc enforces resource requirements enumerated by the pod against
+// the specified LimitRange.
+func PodValidateLimitFunc(limitRange *corev1.LimitRange, pod *api.Pod) error {
+	var errs []error
+
+	for i := range limitRange.Spec.Limits {
+		limit := limitRange.Spec.Limits[i]
+		limitType := limit.Type
+		// enforce container limits
+		if limitType == corev1.LimitTypeContainer {
+			for j := range pod.Spec.Containers {
+				container := &pod.Spec.Containers[j]
+				for k, v := range limit.Min {
+					if err := minConstraint(string(limitType), string(k), v, container.Resources.Requests, container.Resources.Limits); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				for k, v := range limit.Max {
+					if err := maxConstraint(string(limitType), string(k), v, container.Resources.Requests, container.Resources.Limits); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				for k, v := range limit.MaxLimitRequestRatio {
+					if err := limitRequestRatioConstraint(string(limitType), string(k), v, container.Resources.Requests, container.Resources.Limits); err != nil {
+						errs = append(errs, err)
+					}
+				}
+			}
+			for j := range pod.Spec.InitContainers {
+				container := &pod.Spec.InitContainers[j]
+				for k, v := range limit.Min {
+					if err := minConstraint(string(limitType), string(k), v, container.Resources.Requests, container.Resources.Limits); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				for k, v := range limit.Max {
+					if err := maxConstraint(string(limitType), string(k), v, container.Resources.Requests, container.Resources.Limits); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				for k, v := range limit.MaxLimitRequestRatio {
+					if err := limitRequestRatioConstraint(string(limitType), string(k), v, container.Resources.Requests, container.Resources.Limits); err != nil {
+						errs = append(errs, err)
+					}
+				}
+			}
+		}
+
+		// enforce pod limits on init containers
+		if limitType == corev1.LimitTypePod {
+			containerRequests, containerLimits := []api.ResourceList{}, []api.ResourceList{}
+			for j := range pod.Spec.Containers {
+				container := &pod.Spec.Containers[j]
+				containerRequests = append(containerRequests, container.Resources.Requests)
+				containerLimits = append(containerLimits, container.Resources.Limits)
+			}
+			podRequests := sum(containerRequests)
+			podLimits := sum(containerLimits)
+			for j := range pod.Spec.InitContainers {
+				container := &pod.Spec.InitContainers[j]
+				// take max(sum_containers, any_init_container)
+				for k, v := range container.Resources.Requests {
+					if v2, ok := podRequests[k]; ok {
+						if v.Cmp(v2) > 0 {
+							podRequests[k] = v
+						}
+					} else {
+						podRequests[k] = v
+					}
+				}
+				for k, v := range container.Resources.Limits {
+					if v2, ok := podLimits[k]; ok {
+						if v.Cmp(v2) > 0 {
+							podLimits[k] = v
+						}
+					} else {
+						podLimits[k] = v
+					}
+				}
+			}
+			for k, v := range limit.Min {
+				if err := minConstraint(string(limitType), string(k), v, podRequests, podLimits); err != nil {
+					errs = append(errs, err)
+				}
+			}
+			for k, v := range limit.Max {
+				if err := maxConstraint(string(limitType), string(k), v, podRequests, podLimits); err != nil {
+					errs = append(errs, err)
+				}
+			}
+			for k, v := range limit.MaxLimitRequestRatio {
+				if err := limitRequestRatioConstraint(string(limitType), string(k), v, podRequests, podLimits); err != nil {
+					errs = append(errs, err)
+				}
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/interfaces.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/interfaces.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitranger
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// LimitRangerActions is an interface defining actions to be carried over ranges to identify and manipulate their limits
+type LimitRangerActions interface {
+	// MutateLimit is a pluggable function to set limits on the object.
+	MutateLimit(limitRange *corev1.LimitRange, kind string, obj runtime.Object) error
+	// ValidateLimits is a pluggable function to enforce limits on the object.
+	ValidateLimit(limitRange *corev1.LimitRange, kind string, obj runtime.Object) error
+	// SupportsAttributes is a pluggable function to allow overridding what resources the limitranger
+	// supports.
+	SupportsAttributes(attr admission.Attributes) bool
+	// SupportsLimit is a pluggable function to allow ignoring limits that should not be applied
+	// for any reason.
+	SupportsLimit(limitRange *corev1.LimitRange) bool
+}

--- a/vendor/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/vendor/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1267,26 +1267,6 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) VSOCK(arg0, arg1 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "VSOCK", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) AddInterface(ctx context.Context, name string, addInterfaceOptions *v120.AddInterfaceOptions) error {
-	ret := _m.ctrl.Call(_m, "AddInterface", ctx, name, addInterfaceOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) AddInterface(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddInterface", arg0, arg1, arg2)
-}
-
-func (_m *MockVirtualMachineInstanceInterface) RemoveInterface(ctx context.Context, name string, removeInterfaceOptions *v120.RemoveInterfaceOptions) error {
-	ret := _m.ctrl.Call(_m, "RemoveInterface", ctx, name, removeInterfaceOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) RemoveInterface(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveInterface", arg0, arg1, arg2)
-}
-
 // Mock of ReplicaSetInterface interface
 type MockReplicaSetInterface struct {
 	ctrl     *gomock.Controller

--- a/vendor/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/vendor/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -252,8 +252,6 @@ type VirtualMachineInstanceInterface interface {
 	AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error
 	RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error
 	VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, error)
-	AddInterface(ctx context.Context, name string, addInterfaceOptions *v1.AddInterfaceOptions) error
-	RemoveInterface(ctx context.Context, name string, removeInterfaceOptions *v1.RemoveInterfaceOptions) error
 }
 
 type ReplicaSetInterface interface {

--- a/vendor/kubevirt.io/client-go/kubecli/vmi.go
+++ b/vendor/kubevirt.io/client-go/kubecli/vmi.go
@@ -506,25 +506,3 @@ func (v *vmis) VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, er
 	queryParams.Add("tls", strconv.FormatBool(useTLS))
 	return asyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vsock", queryParams)
 }
-
-func (v *vmis) AddInterface(ctx context.Context, name string, addInterfaceOptions *v1.AddInterfaceOptions) error {
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "addinterface")
-
-	JSON, err := json.Marshal(addInterfaceOptions)
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().RequestURI(uri).Body(JSON).Do(ctx).Error()
-}
-
-func (v *vmis) RemoveInterface(ctx context.Context, name string, removeInterfaceOptions *v1.RemoveInterfaceOptions) error {
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "removeinterface")
-
-	JSON, err := json.Marshal(removeInterfaceOptions)
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().RequestURI(uri).Body(JSON).Do(ctx).Error()
-}

--- a/vendor/kubevirt.io/kubevirt/pkg/controller/virtinformers.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/controller/virtinformers.go
@@ -726,28 +726,28 @@ func (f *kubeInformerFactory) VirtualMachineClone() cache.SharedIndexInformer {
 
 func (f *kubeInformerFactory) VirtualMachineInstancetype() cache.SharedIndexInformer {
 	return f.getInformer("vmInstancetypeInformer", func() cache.SharedIndexInformer {
-		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1alpha2().RESTClient(), instancetypeapi.PluralResourceName, k8sv1.NamespaceAll, fields.Everything())
+		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1beta1().RESTClient(), instancetypeapi.PluralResourceName, k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &instancetypev1beta1.VirtualMachineInstancetype{}, f.defaultResync, cache.Indexers{})
 	})
 }
 
 func (f *kubeInformerFactory) VirtualMachineClusterInstancetype() cache.SharedIndexInformer {
 	return f.getInformer("vmClusterInstancetypeInformer", func() cache.SharedIndexInformer {
-		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1alpha2().RESTClient(), instancetypeapi.ClusterPluralResourceName, k8sv1.NamespaceAll, fields.Everything())
+		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1beta1().RESTClient(), instancetypeapi.ClusterPluralResourceName, k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &instancetypev1beta1.VirtualMachineClusterInstancetype{}, f.defaultResync, cache.Indexers{})
 	})
 }
 
 func (f *kubeInformerFactory) VirtualMachinePreference() cache.SharedIndexInformer {
 	return f.getInformer("vmPreferenceInformer", func() cache.SharedIndexInformer {
-		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1alpha2().RESTClient(), instancetypeapi.PluralPreferenceResourceName, k8sv1.NamespaceAll, fields.Everything())
+		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1beta1().RESTClient(), instancetypeapi.PluralPreferenceResourceName, k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &instancetypev1beta1.VirtualMachinePreference{}, f.defaultResync, cache.Indexers{})
 	})
 }
 
 func (f *kubeInformerFactory) VirtualMachineClusterPreference() cache.SharedIndexInformer {
 	return f.getInformer("vmClusterPreferenceInformer", func() cache.SharedIndexInformer {
-		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1alpha2().RESTClient(), instancetypeapi.ClusterPluralPreferenceResourceName, k8sv1.NamespaceAll, fields.Everything())
+		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().InstancetypeV1beta1().RESTClient(), instancetypeapi.ClusterPluralPreferenceResourceName, k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &instancetypev1beta1.VirtualMachineClusterPreference{}, f.defaultResync, cache.Indexers{})
 	})
 }

--- a/vendor/kubevirt.io/kubevirt/pkg/instancetype/instancetype.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/instancetype/instancetype.go
@@ -989,7 +989,8 @@ func applyMemory(field *k8sfield.Path, instancetypeSpec *instancetypev1beta1.Vir
 		if vmiSpec.Domain.Resources.Requests == nil {
 			vmiSpec.Domain.Resources.Requests = k8sv1.ResourceList{}
 		}
-		podRequestedMemory := instancetypeMemoryGuest.Value() * (1 - int64(instancetypeMemoryOvercommit)/int64(totalPercentage))
+		podRequestedMemory := int64(float32(instancetypeSpec.Memory.Guest.Value()) * (1 - float32(instancetypeSpec.Memory.OvercommitPercent)/totalPercentage))
+
 		vmiSpec.Domain.Resources.Requests[k8sv1.ResourceMemory] = *resource.NewQuantity(podRequestedMemory, instancetypeMemoryGuest.Format)
 	}
 

--- a/vendor/kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/vendor/kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coreos/prometheus-operator/pkg/apis/monitoring"
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -88,6 +89,8 @@ func NewPrometheusRuleCR(namespace string, workloadUpdatesEnabled bool) *v1.Prom
 
 // NewPrometheusRuleSpec makes a prometheus rule spec for kubevirt
 func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.PrometheusRuleSpec {
+	fiftyMB := resource.MustParse("50Mi")
+
 	getRestCallsFailedWarning := func(failingCallsPercentage int, component, duration string) string {
 		const restCallsFailWarningTemplate = "More than %d%% of the rest calls failed in %s for the last %s"
 		return fmt.Sprintf(restCallsFailWarningTemplate, failingCallsPercentage, component, duration)
@@ -383,7 +386,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 			Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 52428800 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 52428800"),
 			For:   "1m",
 			Annotations: map[string]string{
-				"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than 20 MB and it is close to requested memory",
+				"description": fmt.Sprintf("Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than %s and it is close to requested memory", fiftyMB.String()),
 				"summary":     "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime.",
 				"runbook_url": fmt.Sprintf(runbookURLTemplate, "KubevirtVmHighMemoryUsage"),
 			},

--- a/vendor/kubevirt.io/kubevirt/tests/BUILD.bazel
+++ b/vendor/kubevirt.io/kubevirt/tests/BUILD.bazel
@@ -174,6 +174,7 @@ go_test(
         "//pkg/hooks/v1alpha1:go_default_library",
         "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/network/dns:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",

--- a/vendor/kubevirt.io/kubevirt/tests/libwait/BUILD.bazel
+++ b/vendor/kubevirt.io/kubevirt/tests/libwait/BUILD.bazel
@@ -10,11 +10,11 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/testsuite:go_default_library",
         "//tests/watcher:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/vendor/kubevirt.io/kubevirt/tests/testsuite/BUILD.bazel
+++ b/vendor/kubevirt.io/kubevirt/tests/testsuite/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "kubevirtresource.go",
         "manifest.go",
         "namespace.go",
+        "runconfiguration.go",
         "serviceaccount.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/testsuite",

--- a/vendor/kubevirt.io/kubevirt/tests/testsuite/fixture.go
+++ b/vendor/kubevirt.io/kubevirt/tests/testsuite/fixture.go
@@ -95,6 +95,7 @@ func SynchronizedBeforeTestSetup() []byte {
 	EnsureKVMPresent()
 	AdjustKubeVirtResource()
 	EnsureKubevirtReady()
+	InitRunConfiguration()
 
 	return nil
 }

--- a/vendor/kubevirt.io/kubevirt/tests/testsuite/namespace.go
+++ b/vendor/kubevirt.io/kubevirt/tests/testsuite/namespace.go
@@ -283,11 +283,7 @@ func CleanNamespaces() {
 		util.PanicOnError(virtCli.VirtualMachineRestore(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 
 		// Remove events
-		eventList, err := virtCli.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
-		util.PanicOnError(err)
-		for _, event := range eventList.Items {
-			util.PanicOnError(virtCli.CoreV1().Events(namespace).Delete(context.Background(), event.Name, metav1.DeleteOptions{}))
-		}
+		util.PanicOnError(virtCli.CoreV1().Events(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 	}
 }
 

--- a/vendor/kubevirt.io/kubevirt/tests/testsuite/runconfiguration.go
+++ b/vendor/kubevirt.io/kubevirt/tests/testsuite/runconfiguration.go
@@ -1,0 +1,23 @@
+package testsuite
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var (
+	TestRunConfiguration RunConfiguration
+)
+
+type RunConfiguration struct {
+	WarningToIgnoreList []string
+}
+
+func InitRunConfiguration() {
+	runConfig := RunConfiguration{}
+	if KubeVirtDefaultConfig.EvictionStrategy != nil &&
+		*KubeVirtDefaultConfig.EvictionStrategy == v1.EvictionStrategyLiveMigrate {
+		runConfig.WarningToIgnoreList = append(runConfig.WarningToIgnoreList, "EvictionStrategy is set but vmi is not migratable")
+	}
+
+	TestRunConfiguration = runConfig
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1135,7 +1135,7 @@ k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# kubevirt.io/api v1.0.0-rc.0
+# kubevirt.io/api v1.0.0
 ## explicit; go 1.17
 kubevirt.io/api/clone
 kubevirt.io/api/clone/v1alpha1
@@ -1153,7 +1153,7 @@ kubevirt.io/api/pool
 kubevirt.io/api/pool/v1alpha1
 kubevirt.io/api/snapshot
 kubevirt.io/api/snapshot/v1alpha1
-# kubevirt.io/client-go v1.0.0-rc.0
+# kubevirt.io/client-go v1.0.0
 ## explicit; go 1.17
 kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned
 kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme
@@ -1203,7 +1203,7 @@ kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources
 # kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 => kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 ## explicit; go 1.17
 kubevirt.io/controller-lifecycle-operator-sdk/api
-# kubevirt.io/kubevirt v1.0.0-rc.0
+# kubevirt.io/kubevirt v1.0.0
 ## explicit; go 1.19
 kubevirt.io/kubevirt/pkg/apimachinery/patch
 kubevirt.io/kubevirt/pkg/certificates/bootstrap

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -401,6 +401,9 @@ golang.org/x/net/trace
 ## explicit; go 1.11
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
+# golang.org/x/sync v0.2.0
+## explicit
+golang.org/x/sync/singleflight
 # golang.org/x/sys v0.8.0
 ## explicit; go 1.17
 golang.org/x/sys/cpu
@@ -1122,6 +1125,7 @@ k8s.io/kubernetes/pkg/apis/core/v1/helper/qos
 k8s.io/kubernetes/pkg/features
 k8s.io/kubernetes/pkg/quota/v1/evaluator/core
 k8s.io/kubernetes/pkg/util/parsers
+k8s.io/kubernetes/plugin/pkg/admission/limitranger
 # k8s.io/utils v0.0.0-20230505201702-9f6742963106
 ## explicit; go 1.18
 k8s.io/utils/buffer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add limit range support so the target launcher
Will include the limit range defaults for
the calculation that determine if the migration
can be released by increasing the rq with vmmrq
resources.
    
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
