### PR TITLE
Enqueue all blocking migrations periodically and Update validatingWebhookConfiguration when it's invalid

### DIFF
--- a/pkg/mtq-controller/vmmrq-controller/vmmrq-controller.go
+++ b/pkg/mtq-controller/vmmrq-controller/vmmrq-controller.go
@@ -318,7 +318,8 @@ func (ctrl *VmmrqController) execute(key string) (error, enqueueState) {
 	case namespace_lock_utils.Unlocked:
 		nsLocked = false
 	case namespace_lock_utils.Unknown: //expensive api call
-		nsLocked, err = webhooklock.NamespaceLocked(migartionNS, ctrl.mtqNs, ctrl.virtCli)
+		caBundle, err := ctrl.serverBundleFetcher.BundleBytes()
+		nsLocked, err = webhooklock.NamespaceLocked(migartionNS, ctrl.mtqNs, ctrl.virtCli, caBundle)
 		if err != nil {
 			return err, Immediate
 		}

--- a/pkg/validating-webhook-lock/validating-webhook-lock.go
+++ b/pkg/validating-webhook-lock/validating-webhook-lock.go
@@ -1,6 +1,7 @@
 package validating_webhook_lock
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	v13 "k8s.io/api/admissionregistration/v1"
@@ -8,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
 	"reflect"
 )
 
@@ -40,46 +42,69 @@ func UnlockNamespace(ns string, cli kubecli.KubevirtClient) error {
 	return nil
 }
 
-func NamespaceLocked(nsToVerify string, mtqNs string, cli kubecli.KubevirtClient) (bool, error) {
+func NamespaceLocked(nsToVerify string, mtqNs string, cli kubecli.KubevirtClient, caBundle []byte) (bool, error) {
 	webhookName := "lock." + nsToVerify + ".com"
 	ValidatingWH, err := cli.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), webhookName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
 		return false, err
-	} else if !isOurValidatingWebhookConfiguration(nsToVerify, mtqNs, ValidatingWH) {
-		return false, fmt.Errorf("ValidatingWebhookConfiguration with name " + webhookName + " and diffrent logic already exist")
+	} else if !isOurValidatingWebhookConfiguration(nsToVerify, mtqNs, ValidatingWH, caBundle) {
+		ValidatingWH.Webhooks = []v13.ValidatingWebhook{getLockingValidatingWebhook(mtqNs, nsToVerify, caBundle)}
+		_, err := cli.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(context.Background(), ValidatingWH, metav1.UpdateOptions{})
+		if err != nil {
+			return false, err
+		}
 	}
 	return true, nil
 }
 
-func isOurValidatingWebhookConfiguration(mtqNs string, lockedNs string, existingVWHC *v13.ValidatingWebhookConfiguration) bool {
-	expectedVWH := getLockingValidatingWebhook(mtqNs, lockedNs, []byte{})
+func isOurValidatingWebhookConfiguration(mtqNs string, lockedNs string, existingVWHC *v13.ValidatingWebhookConfiguration, caBundle []byte) bool {
+	expectedVWH := getLockingValidatingWebhook(mtqNs, lockedNs, caBundle)
 	if len(existingVWHC.Webhooks) != 1 {
 		return false
 	}
 
 	existingVWH := existingVWHC.Webhooks[0]
-
 	expectedClientConfigSvc := expectedVWH.ClientConfig.Service
 	existingClientConfigSvc := existingVWH.ClientConfig.Service
 	expectedRules := expectedVWH.Rules
 	existingRules := existingVWH.Rules
 
-	if existingVWH.Name != expectedVWH.Name ||
-		!reflect.DeepEqual(existingVWH.AdmissionReviewVersions, expectedVWH.AdmissionReviewVersions) ||
-		!reflect.DeepEqual(existingVWH.NamespaceSelector, expectedVWH.NamespaceSelector) ||
-		*existingVWH.FailurePolicy != *expectedVWH.FailurePolicy ||
-		*existingVWH.SideEffects != *expectedVWH.SideEffects ||
-		*existingVWH.MatchPolicy != *expectedVWH.MatchPolicy {
-
+	if !bytes.Equal(existingVWH.ClientConfig.CABundle, expectedVWH.ClientConfig.CABundle) {
+		log.Log.Infof("Found WHC doesn't match our CABundles do not match")
+		return false
+	}
+	if existingVWH.Name != expectedVWH.Name {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our existingVWH.Name %v expectedVWH.Name %v ", existingVWH.Name, expectedVWH.Name))
+		return false
+	}
+	if !reflect.DeepEqual(existingVWH.AdmissionReviewVersions, expectedVWH.AdmissionReviewVersions) {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our existingVWH.AdmissionReviewVersions %v expectedVWH.AdmissionReviewVersions %v ", existingVWH.AdmissionReviewVersions, expectedVWH.AdmissionReviewVersions))
+		return false
+	}
+	if !reflect.DeepEqual(existingVWH.NamespaceSelector, expectedVWH.NamespaceSelector) {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our existingVWH.NamespaceSelector %v expectedVWH.AdmissionReviewVersions %v ", existingVWH.NamespaceSelector, expectedVWH.NamespaceSelector))
+		return false
+	}
+	if existingVWH.FailurePolicy == nil || *existingVWH.FailurePolicy != *expectedVWH.FailurePolicy {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our *existingVWH.FailurePolicy  %v *expectedVWH.FailurePolicy %v ", *existingVWH.FailurePolicy, *expectedVWH.FailurePolicy))
+		return false
+	}
+	if existingVWH.SideEffects == nil || *existingVWH.SideEffects != *expectedVWH.SideEffects {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our existingVWH.SideEffects %v expectedVWH.SideEffects %v ", existingVWH.SideEffects, expectedVWH.SideEffects))
+		return false
+	}
+	if existingVWH.MatchPolicy == nil || *existingVWH.MatchPolicy != *expectedVWH.MatchPolicy {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our existingVWH.MatchPolicy %v expectedVWH.MatchPolicy %v ", existingVWH.MatchPolicy, expectedVWH.MatchPolicy))
 		return false
 	}
 	if !reflect.DeepEqual(expectedClientConfigSvc, existingClientConfigSvc) {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our expectedClientConfigSvc %v existingClientConfigSvc %v ", expectedClientConfigSvc, existingClientConfigSvc))
 		return false
 	}
-
 	if !reflect.DeepEqual(expectedRules, existingRules) {
+		log.Log.Infof(fmt.Sprintf("Found WHC doesn't match our expectedRules %v existingRules %v ", expectedRules, existingRules))
 		return false
 	}
 

--- a/tests/mtq_operator_test.go
+++ b/tests/mtq_operator_test.go
@@ -503,10 +503,13 @@ var _ = Describe("ALL Operator tests", func() {
 			})
 
 			AfterEach(func() {
-				cr := getMTQ(f)
-				cr.Spec.PriorityClass = mtq.Spec.PriorityClass
-				_, err := f.MtqClient.MtqV1alpha1().MTQs().Update(context.TODO(), cr, metav1.UpdateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				var cr *mtqv1.MTQ
+				Eventually(func() error {
+					cr = getMTQ(f)
+					cr.Spec.PriorityClass = mtq.Spec.PriorityClass
+					_, err := f.MtqClient.MtqV1alpha1().MTQs().Update(context.TODO(), cr, metav1.UpdateOptions{})
+					return err
+				}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 
 				if !utils.IsOpenshift(f.K8sClient) {
 					Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enqueue all blocking migrations every 30 second
To make sure we handle all migrations
even if operator installed after migrations
Are blocked.
Update validatingWebhookConfiguration
If something is wrong instead of returning
An error this could happen if the controller
was deleted while the ns is lock typically in
Node drain.
Update logging for better debugging.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
