### PR TITLE
Fix vmmrq creation with no pending migrations

### DIFF
--- a/pkg/mtq-controller/vmmrq-controller/vmmrq-controller.go
+++ b/pkg/mtq-controller/vmmrq-controller/vmmrq-controller.go
@@ -298,6 +298,7 @@ func (ctrl *VmmrqController) execute(key string) (error, enqueueState) {
 	var migration *v1alpha1.VirtualMachineInstanceMigration
 	var vmi *v1alpha1.VirtualMachineInstance
 	isBlockedMigration := false
+	reachedMaxParallelMigrations := false
 
 	if migrationExists {
 		migration = migrationObj.(*v1alpha1.VirtualMachineInstanceMigration)
@@ -312,10 +313,10 @@ func (ctrl *VmmrqController) execute(key string) (error, enqueueState) {
 		if err != nil {
 			return err, BackOff
 		}
-	}
-	reachedMaxParallelMigrations, err := ctrl.reachedMaxParallelMigration(vmi.Status.NodeName)
-	if err != nil {
-		return err, Immediate
+		reachedMaxParallelMigrations, err = ctrl.reachedMaxParallelMigration(vmi.Status.NodeName)
+		if err != nil {
+			return err, Immediate
+		}
 	}
 
 	finalEnqueueState := Forget


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
During the vmmrq creation, if there are no migration, a fake one is queued to update the vmmrq status.

The `reachedMaxParallelMigration` function should be call only if there is a real vmi associated to the migration.
Otherwise, a nil pointer dereference error is triggered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @Barakmor1 @vladikr 