### PR TITLE
Builder:Update ginkgo version to the right path and update golang version of aaq images

### DIFF
--- a/Dockerfile.mtq-controller
+++ b/Dockerfile.mtq-controller
@@ -1,5 +1,5 @@
 # Builder stage
-FROM docker.io/library/golang:1.19-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 # Install make
 RUN apk update && apk add make
@@ -18,7 +18,7 @@ WORKDIR /workdir/app
 RUN make mtq_controller
 
 # Final stage
-FROM docker.io/library/golang:1.19-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 # Copy the binary from the builder stage to the final image
 COPY --from=builder /workdir/app/mtq_controller /app/mtq_controller

--- a/Dockerfile.mtq-lock-server
+++ b/Dockerfile.mtq-lock-server
@@ -1,5 +1,5 @@
 # Builder stage
-FROM docker.io/library/golang:1.19-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 # Install make
 RUN apk update && apk add make
@@ -18,7 +18,7 @@ WORKDIR /workdir/app
 RUN make mtq_lock_server
 
 # Final stage
-FROM docker.io/library/golang:1.19-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 # Copy the binary from the builder stage to the final image
 COPY --from=builder /workdir/app/mtq_lock_server /app/mtq_lock_server

--- a/Dockerfile.mtq-operator
+++ b/Dockerfile.mtq-operator
@@ -1,5 +1,5 @@
 # Builder stage
-FROM docker.io/library/golang:1.19-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 
 # Install make
@@ -21,7 +21,7 @@ RUN make mtq_operator
 RUN make csv-generator
 
 # Final stage
-FROM docker.io/library/golang:1.19-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 
 # Copy the binary from the builder stage to the final image

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimm
 RUN \
 	source /etc/profile.d/gimme.sh && \
 	eval $(go env) && \
-	go install github.com/onsi/ginkgo/ginkgo@v2.12.0 && \
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.12.0 && \
 	go install mvdan.cc/sh/cmd/shfmt@latest && \
 	go install github.com/mattn/goveralls@latest && \
 	go install golang.org/x/lint/golint@latest && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Builder:Update ginkgo version to the right path
Align pods Images to align with the builder to go version 1.22

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
